### PR TITLE
Add streamlit config to bind to 127.0.0.1 by default

### DIFF
--- a/src/analysis_tool/.streamlit/config.toml
+++ b/src/analysis_tool/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+address = "127.0.0.1"


### PR DESCRIPTION
By default, streamlit binds on all available network interfaces, meaning that depending on firewall settings others on the same network (or even on the internet, if you have a public IP) may be able to view the dashboard. This adds a streamlit config file to bind only on 127.0.0.1 (localhost), preventing access from others. This may not always be desirable but I think it should be the default.

This will work as long as the `streamlit` command is run with `analysis_tool` as the working directory.