### PR TITLE
update bike data to version fe43e

### DIFF
--- a/data_viz/vmt_viz_routes_2.ipynb
+++ b/data_viz/vmt_viz_routes_2.ipynb
@@ -19,7 +19,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -37,7 +39,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import math\n",
@@ -56,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pd.set_option('display.max_rows', 500)\n",
@@ -67,7 +73,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%html\n",
@@ -82,7 +90,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# This is used to avoid hard-coding directories. \n",
@@ -97,7 +107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# read in the data\n",
@@ -107,13 +119,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# read path geopkg data\n",
     "# parquet files take an order of magnitude less time to read\n",
     "car = gpd.read_parquet(data_dir + \"/Data_Processed/geodata/car_congestion_1d39c/car_congestion.parquet\")\n",
-    "bike = gpd.read_parquet(data_dir + \"/Data_Processed/geodata/bike-trips-1d39c.parquet\")\n",
+    "bike = gpd.read_parquet(data_dir + \"/Data_Processed/geodata/bike-trips-fe43e.parquet\")\n",
     "transit = gpd.read_parquet(data_dir + \"/Data_Processed/geodata/transit-trips-93d71.parquet\")\n",
     "walk = gpd.read_parquet(data_dir + \"/Data_Processed/geodata/walk-trips-1d39c.parquet\")"
    ]
@@ -121,7 +135,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# grab the observed routes\n",
@@ -131,7 +147,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# calculate duration from start/end times\n",
@@ -144,7 +162,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# create a gdf for linked trips\n",
@@ -183,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# reload is only needed if we make changes to the module\n",
@@ -205,7 +227,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# option 1 is just to map a randomly selected trip\n",
@@ -215,7 +239,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# or I can specify a specific trip ID\n",
@@ -292,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.11.2"
   },
   "vscode": {
    "interpreter": {
@@ -301,5 +327,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This updates the bike trips in the route visualizer to version https://github.com/Metropolitan-Council/vmt-mode-shift-study/commit/fe43e3cb76fc4b7c8c8688d620301dce4e81c035, which fixes an issue with one-way streets not being treated as one-way.

It seems I have a newer Python/Jupyter on my system and it updated the notebook format to v4.4. I think it should be backwards compatible.