### PR TITLE
Clean up network build script names

### DIFF
--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -22,11 +22,9 @@ First, we need to download the data. The script `download_elevation_data.jl` wil
 
 Once the elevation data files are downloaded, several more steps need to happen. They need to be combined into a single file for the analysis area, they need to be reprojected from NAD83 (used by USGS) to WGS84 (used by OSM/OSRM), and they need to be converted to the text-based grid format OSRM requires. OSRM additionally requires that all raster data be integers, so that needs to be done. To minimize rounding errors, we also convert the elevations to millimeters above mean sea level. The shell script `prepare_elevation_data.sh` handles these steps. Since this is a shell script, it will only run on macOS or Linux; if you are using Windows, I recommend installing the Windows Subsystem for Linux. You will need it to run OSRM anyhow. You pass in the path to directory you downloaded the elevation to. This will create three new files: combined.tif, which is a GeoTIFF combining all of the elevation tiles into a single dataset; final.asc, which is the OSRM-format raster grid, and final_header.asc, which contains information about the spatial extent of the file. This spatial extent should match the variables declared at the top of `profiles/elevation.lua`.
 
-    prepare
-
 ### Street network
 
-OSRM requires the original `analysis-area.osm.pbf` to be processed into a network, using a "profile" that assigns weights. Eventually, we will have custom profiles that account for slopes, safety, traffic congestion, and so on, but for now we are using the profiles that ship with OSRM. The `build_network.sh` script will build the network, taking arguments for the path to the network, the path to the profile, and the name of the directory where you want the final network to reside (must not already exist). If you're running under WSL, I recommend keeping you networks within WSL (i.e. not under /mnt/c/...) because symbolic links are used during the network build process.
+OSRM requires the original `analysis-area.osm.pbf` to be processed into a network, using a "profile" that assigns weights. Eventually, we will have custom profiles that account for slopes, safety, traffic congestion, and so on, but for now we are using the profiles that ship with OSRM. The `build_*_network.sh` scripts will build the networks, taking arguments for the path to the network and the name of the directory where you want the final network to reside (must not already exist; each network should have its own directory). If you're running under WSL, I recommend keeping you networks within WSL (i.e. not under /mnt/c/...) because symbolic links are used during the network build process.
 
 #### Environment variables
 
@@ -34,10 +32,9 @@ The profiles expect three environment variables to be set: `SPEED_DATABASE`, the
 
 #### Building the network
 
-I used these commands, putting my networks in `~/vmt-networks/<network_name>` and using the default installation location for OSRM profiles:
+I used these commands, putting my networks in `~/vmt-networks/` and using the default installation location for OSRM profiles:
 
-    bash build_street_network.sh /path/to/analysis-area.osm.pbf profiles/foot_lts.lua ~/vmt-networks/walk-lts
-    bash build_street_network.sh /path/to/analysis-area.osm.pbf profiles/bicycle_lts.lua ~/vmt-networks/bike-lts
+    bash build_<network_name>_network.sh /path/to/analysis-area.osm.pbf ~/vmt-networks/
 
 These will take a few minutes to run.
 
@@ -55,7 +52,7 @@ OSRM does have functionality to update speeds on the fly, but we do not use this
             sqlite3 "$SPEED_DATABASE" |
             grep REAL |
             sed -E 's/^ +"([^"]+).*$/\1/' | 
-            xargs -n 1 -Icol env SPEED_COLUMN=col bash build_street_network.sh ~/vmt-networks/analysis-area.osm.pbf profiles/car_traffic.lua ~/vmt-networks/car_col
+            xargs -n 1 -Icol env SPEED_COLUMN=col bash _build_street_network.sh ~/vmt-networks/analysis-area.osm.pbf profiles/car_traffic.lua ~/vmt-networks/car_col
     )
 
 (The parentheses are optional, but create a subshell to avoid polluting the main environment in your shell. `export` is necessary because we need SPEED_DATABASE to be available in the variable expansion after `sqlite3` - otherwise that variable expansion occurs before the variable is set).

--- a/src/routing/_build_street_network.sh
+++ b/src/routing/_build_street_network.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Build the OSRM network based on an OSM file, a profile, and an output directory
+# Build the OSRM network based on an OSM file, a profile, and an output directory.
+# This generally should not be used directly, but rather called from one of the build_*_network.sh
+# scripts which encapsulate the settings needed for any particular network.
 set -ex
 
 OSM_FILE="${1}"

--- a/src/routing/build_bicycle_all_lts1_network.sh
+++ b/src/routing/build_bicycle_all_lts1_network.sh
@@ -13,4 +13,4 @@ PROFILE="$(dirname "$0")/profiles/bicycle_lts.lua"
 export SPEED_COLUMN="saturdays_6-7"
 export BIKE_SCENARIO="all-lts1"
 
-bash build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-all-lts1"
+bash _build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-all-lts1"

--- a/src/routing/build_bicycle_baseline_network.sh
+++ b/src/routing/build_bicycle_baseline_network.sh
@@ -13,4 +13,4 @@ PROFILE="$(dirname "$0")/profiles/bicycle_lts.lua"
 export SPEED_COLUMN="saturdays_6-7"
 export BIKE_SCENARIO="baseline"
 
-bash build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-baseline"
+bash _build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-baseline"

--- a/src/routing/build_bicycle_ebike_network.sh
+++ b/src/routing/build_bicycle_ebike_network.sh
@@ -13,4 +13,4 @@ PROFILE="$(dirname "$0")/profiles/bicycle_lts.lua"
 export SPEED_COLUMN="saturdays_6-7"
 export BIKE_SCENARIO="e-bike"
 
-bash build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-ebike"
+bash _build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/bike-ebike"

--- a/src/routing/build_car_baseline_networks.sh
+++ b/src/routing/build_car_baseline_networks.sh
@@ -19,5 +19,5 @@ echo ".schema stl_congestion_data_2019" |
     sqlite3 "$SPEED_DATABASE" |
     grep REAL |
     sed -E 's/^ +"([^"]+).*$/\1/' | 
-    xargs -Icol env SPEED_COLUMN=col bash "$(dirname "$0")/build_street_network.sh" "$OSM" "$PROFILE" "${OUTDIR}/car_baseline_col"
+    xargs -Icol env SPEED_COLUMN=col bash "$(dirname "$0")/_build_street_network.sh" "$OSM" "$PROFILE" "${OUTDIR}/car_baseline_col"
 

--- a/src/routing/build_car_speed_scenario_networks.sh
+++ b/src/routing/build_car_speed_scenario_networks.sh
@@ -19,5 +19,5 @@ echo ".schema stl_congestion_data_2019" |
     sqlite3 "$SPEED_DATABASE" |
     grep REAL |
     sed -E 's/^ +"([^"]+).*$/\1/' | 
-    xargs -Icol env SPEED_COLUMN=col SPEED_CAP_DATABASE="$SPEED_CAP_DB" bash "$(dirname "$0")/build_street_network.sh" "$OSM" "$PROFILE" "${OUTDIR}/car_scenario_col"
+    xargs -Icol env SPEED_COLUMN=col SPEED_CAP_DATABASE="$SPEED_CAP_DB" bash "$(dirname "$0")/_build_street_network.sh" "$OSM" "$PROFILE" "${OUTDIR}/car_scenario_col"
 

--- a/src/routing/build_walk_baseline_network.sh
+++ b/src/routing/build_walk_baseline_network.sh
@@ -13,4 +13,4 @@ PROFILE="$(dirname "$0")/profiles/foot_lts.lua"
 export SPEED_COLUMN="saturdays_6-7"
 unset SPEED_CAP_DATABASE
 
-bash build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/walk-baseline"
+bash _build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/walk-baseline"

--- a/src/routing/build_walk_scenario_network.sh
+++ b/src/routing/build_walk_scenario_network.sh
@@ -13,4 +13,4 @@ PROFILE="$(dirname "$0")/profiles/foot_scenario.lua"
 export SPEED_COLUMN="saturdays_6-7"
 unset SPEED_CAP_DATABASE
 
-bash build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/walk-scenario"
+bash _build_street_network.sh "$OSM" "$PROFILE" "${OUTDIR}/walk-scenario"


### PR DESCRIPTION
@eroten my apologies for forgetting about this; this cleans up the network build script names as you requested. The scripts do run; on my machine I am getting an OSRM error unrelated to this change (below), which I suspect is a version issue. I think it should work in the Docker image but I don't currently have docker configured—if you run into any trouble with network builds I'm happy to investigate further.

```
terminate called after throwing an instance of 'osrm::util::exception'
  what():  Maximum number of classes is 8
```